### PR TITLE
Add init_params which forwards parameters to Logger::new

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Add `include EasyLogging` to any context (e.g. a class) you want to extend with 
 ```ruby
 require 'easy_logging'
 EasyLogging.log_destination = 'app.log'
+# Alternatively, EasyLogging::init_params accepts the same parameters as
+# Logger::new. Thus,
+#   EasyLogging.log_destination = 'app.log'
+# is equivalent to
+#   EasyLogging.init_params('app.log')
 EasyLogging.level = Logger::DEBUG
 
 class YourClass
@@ -102,6 +107,17 @@ end
 Default: Logger default
 
 Since: [v0.3.0](https://github.com/thisismydesign/easy_logging/releases/tag/v0.3.0)
+
+#### Init Params
+
+List of parameters to be passed to `Logger::initialize`.
+Overrides `log_destination`, and is selectively overridden by `level` and `formatter`.
+
+```ruby
+EasyLogging.init_params('app.log', 'daily')
+```
+
+Default: `STDOUT`
 
 #### Changing configuration on the fly
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ Add `include EasyLogging` to any context (e.g. a class) you want to extend with 
 ```ruby
 require 'easy_logging'
 EasyLogging.log_destination = 'app.log'
-# Alternatively, EasyLogging::init_params accepts the same parameters as
+# Alternatively, EasyLogging::init accepts the same parameters as
 # Logger::new. Thus,
 #   EasyLogging.log_destination = 'app.log'
 # is equivalent to
-#   EasyLogging.init_params('app.log')
+#   EasyLogging.init('app.log')
 EasyLogging.level = Logger::DEBUG
 
 class YourClass
@@ -114,7 +114,7 @@ List of parameters to be passed to `Logger::initialize`.
 Overrides `log_destination`, and is selectively overridden by `level` and `formatter`.
 
 ```ruby
-EasyLogging.init_params('app.log', 'daily')
+EasyLogging.init('app.log', 'daily')
 ```
 
 Default: `STDOUT`

--- a/lib/easy_logging.rb
+++ b/lib/easy_logging.rb
@@ -12,14 +12,24 @@ module EasyLogging
     end
   end
 
-  class << self; attr_accessor :log_destination, :level, :formatter; end
+  class << self
+    attr_reader :init_params, :log_destination
+    attr_accessor :level, :formatter
+  end
 
   @log_destination = STDOUT
+  @init_params = [@log_destination]
   @level = Logger::INFO
   @loggers = {}
 
+  def self.init(*params)
+    @init_params = params
+    @log_destination = params[0]
+  end
+
   def self.log_destination=(dest)
     @log_destination = dest
+    @init_params = @init_params.drop(1).unshift(dest)
   end
 
   def self.level=(level)
@@ -49,7 +59,7 @@ module EasyLogging
   end
 
   def self.configure_logger_for(classname)
-    logger = Logger.new(log_destination)
+    logger = Logger.new(*init_params)
     logger.level = level
     logger.progname = classname
     logger.formatter = formatter unless formatter.nil?


### PR DESCRIPTION
As I like to pass, for instance, `shift_age = 'daily'`, I took the liberty to add a `::init_params` method which essentially forwards its parameters to `Logger::new`.